### PR TITLE
Add zws.im URL shortener

### DIFF
--- a/zws.im.sxcu
+++ b/zws.im.sxcu
@@ -1,0 +1,11 @@
+{
+  "Version": "13.0.0",
+  "Name": "zws.im",
+  "DestinationType": "URLShortener",
+  "RequestMethod": "GET",
+  "RequestURL": "https://us-central1-zero-width-shortener.cloudfunctions.net/shortenURL",
+  "Parameters": {
+    "url": "$input$"
+  },
+  "URL": "https://zws.im/$json:short$"
+}


### PR DESCRIPTION
Adds support for the URL shortener "zws.im" using the config you wrote [here](https://discordapp.com/channels/117093893345902593/172142599296122880/589972341706981379).