### PR TITLE
Add pixeldrain.com uploader

### DIFF
--- a/pixeldrain.com.sxcu
+++ b/pixeldrain.com.sxcu
@@ -1,0 +1,10 @@
+{
+  "Version": "12.4.1",
+  "DestinationType": "ImageUploader, TextUploader, FileUploader",
+  "RequestMethod": "POST",
+  "RequestURL": "https://pixeldrain.com/api/file",
+  "Body": "MultipartFormData",
+  "FileFormName": "file",
+  "URL": "https://pixeldrain.com/u/$json:id$",
+  "ThumbnailURL": "https://pixeldrain.com/api/file/$json:id$/thumbnail"
+}


### PR DESCRIPTION
I'm the creator of pixeldrain.com, a file sharing website with over a hundred thousand unique monthly visitors. Pixeldrain supports online previews for images, videos, audio, text and PDF documents.

Please consider adding this uploader to the main ShareX project too. I'll create a page on pixeldrain.com recommending ShareX as an officially supported desktop client.