### PR TITLE
Update pictshare request URL

### DIFF
--- a/pictshare.net.sxcu
+++ b/pictshare.net.sxcu
@@ -1,7 +1,7 @@
 ﻿{
-  "Version": "12.4.1",
+  "Version": "12.4.2",
   "RequestMethod": "POST",
-  "RequestURL": "https://www.pictshare.net/backend.php",
+  "RequestURL": "https://pictshare.net/api/upload.php",
   "Body": "MultipartFormData",
   "FileFormName": "postimage",
   "URL": "http://www.pictshare.net/$json:hash$",


### PR DESCRIPTION
This PR changes pictshare's `RequestURL` to its [new upload URL](https://github.com/HaschekSolutions/pictshare/blob/master/rtfm/API.md#uploadphp).