### PR TITLE
Change FileFormName on pictshare.net.sxcu

### DIFF
--- a/pictshare.net.sxcu
+++ b/pictshare.net.sxcu
@@ -3,7 +3,7 @@
   "RequestMethod": "POST",
   "RequestURL": "https://pictshare.net/api/upload.php",
   "Body": "MultipartFormData",
-  "FileFormName": "postimage",
+  "FileFormName": "file",
   "URL": "http://www.pictshare.net/$json:hash$",
   "ThumbnailURL": "http://www.pictshare.net/300x300/$json:hash$"
 }


### PR DESCRIPTION
Post var name is "file" not "postimage"

https://github.com/HaschekSolutions/pictshare/blob/master/rtfm/API.md