### PR TITLE
Update paste.ubuntu.com.sxcu

### DIFF
--- a/paste.ubuntu.com.sxcu
+++ b/paste.ubuntu.com.sxcu
@@ -1,11 +1,14 @@
 {
-  "Version": "12.4.1",
+  "Version": "13.5.0",
+  "Name": "Ubuntu Pastebin",
+  "DestinationType": "TextUploader",
   "RequestMethod": "POST",
   "RequestURL": "https://paste.ubuntu.com/",
   "Body": "MultipartFormData",
   "Arguments": {
     "poster": "ShareX",
-    "syntax": "text",
+    "syntax": "$prompt:Choose syntax highlighting language|text$",
+    "expiration": null,
     "content": "$input$"
   },
   "URL": "$responseurl$"


### PR DESCRIPTION
## Issues fixed by this pull request:


### Missing `expiration` form field

The current custom uploader for [paste.ubuntu.com](https://paste.ubuntu.com) is missing the `expiration` form field. I've left it `null` here to preserve non-expiring uploads by default. 

(Also because I can't specify `null` as an option for a `$select$`, as far as I can tell from the docs.)


### User-defined syntax highlighting

Ubuntu Pastebin supports syntax highlighting for > 400 languages by default. I added a `$prompt$` that defaults to `text` (the old default) but allows the user to input `python3`, `ts`, `yaml`, etc.


### Specify Name and Destination Type

The current version of the Ubuntu Pastebin uploader does not specify `"Name"` or `"DestinationType"`. I added these.