### PR TITLE
Add rustypaste to CustomUploaders

### DIFF
--- a/rustypaste (Image uploader).sxcu
+++ b/rustypaste (Image uploader).sxcu
@@ -1,0 +1,13 @@
+{
+  "Version": "13.0.0",
+  "Name": "rustypaste-img",
+  "DestinationType": "ImageUploader, TextUploader, FileUploader",
+  "RequestMethod": "POST",
+  "RequestURL": "https://[your instance's url]",
+  "Headers": {
+    "Authorization": "[your instance's auth token]"
+  },
+  "Body": "MultipartFormData",
+  "FileFormName": "file"
+}
+

--- a/rustypaste (URL shortener)
+++ b/rustypaste (URL shortener)
@@ -1,0 +1,14 @@
+{
+  "Version": "13.0.0",
+  "Name": "rustypaste-url",
+  "DestinationType": "URLShortener",
+  "RequestMethod": "POST",
+  "RequestURL": "https://[your instance's url]",
+  "Headers": {
+    "Authorization": "[your instance's auth token]"
+  },
+  "Body": "MultipartFormData",
+  "Arguments": {
+    "url": "$input$"
+  }
+}


### PR DESCRIPTION
I've been using rustypaste for quite a while as it's very light on resources on my server, here is a link to the project: https://github.com/orhun/rustypaste

The submitted PR has 2 files:
- for image, text and file uploads
- for url shortening

Authorization is optional depending on how you configure the server side.